### PR TITLE
feat(auth): add axios interceptor for 401 refresh and Zustand auth store with router integration

### DIFF
--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -1,8 +1,75 @@
-import axios from "axios";
+import axios, { AxiosError, type AxiosRequestConfig } from "axios";
 
 export const API_BASE = import.meta.env.DEV ? "/api" : "";
+
+/** Single axios instance for the whole app */
 export const api = axios.create({
     baseURL: API_BASE,
-    withCredentials: true,
+    withCredentials: true, // send/receive HttpOnly cookies
     headers: { "Content-Type": "application/json" },
 });
+
+/** Mark config as retried once to avoid infinite loops */
+type RetriableConfig = AxiosRequestConfig & { _retry?: boolean };
+
+/** Avoid parallel refresh storms */
+let isRefreshing = false;
+let pendingQueue: Array<() => void> = [];
+
+function onRefreshed() {
+    pendingQueue.forEach((resolve) => resolve());
+    pendingQueue = [];
+}
+
+function redirectToLogin() {
+    // keep it simple; works anywhere (no hooks)
+    window.location.replace("/login");
+}
+
+/** RESPONSE INTERCEPTOR */
+api.interceptors.response.use(
+    (res) => res,
+    async (error: AxiosError) => {
+        const { config, response } = error;
+        const original = config as RetriableConfig;
+
+        // If no response or not 401 → just reject
+        if (!response || response.status !== 401) {
+            return Promise.reject(error);
+        }
+
+        // Do not try to refresh on auth endpoints themselves
+        const url = original?.url ?? "";
+        if (url?.startsWith("/auth/login") || url?.startsWith("/auth/register") || url?.startsWith("/auth/refresh")) {
+            redirectToLogin();
+            return Promise.reject(error);
+        }
+
+        // Already retried once → give up
+        if (original?._retry) {
+            redirectToLogin();
+            return Promise.reject(error);
+        }
+
+        // Queue the retry until refresh completes
+        if (isRefreshing) {
+            await new Promise<void>((resolve) => pendingQueue.push(resolve));
+            original._retry = true;
+            return api(original); // retry after someone else refreshed
+        }
+
+        // Perform refresh
+        try {
+            isRefreshing = true;
+            await api.post("/auth/refresh"); // sets new cookies
+            onRefreshed();
+            original._retry = true;
+            return api(original); // retry original call
+        } catch (e) {
+            redirectToLogin();
+            return Promise.reject(e);
+        } finally {
+            isRefreshing = false;
+        }
+    }
+);

--- a/frontend/src/app/App.tsx
+++ b/frontend/src/app/App.tsx
@@ -1,7 +1,14 @@
-import { ThemeProvider } from "./providers/ThemeProvider.tsx";
-import { RouterProvider } from "./providers/RouterProvider.tsx";
+import { useEffect } from "react";
+import { useAuthStore } from "../store/authStore";
+import { ThemeProvider } from "./providers/ThemeProvider";
+import { RouterProvider } from "./providers/RouterProvider";
 
 function App() {
+    const fetchUser = useAuthStore((s) => s.fetchUser);
+
+    useEffect(() => {
+        fetchUser();
+    }, [fetchUser]);
 
   return (
       <ThemeProvider>

--- a/frontend/src/app/providers/RouterProvider.tsx
+++ b/frontend/src/app/providers/RouterProvider.tsx
@@ -1,4 +1,4 @@
-import { BrowserRouter, Routes, Route } from "react-router-dom";
+import {BrowserRouter, Routes, Route, Navigate} from "react-router-dom";
 import HomePage from "../../pages/Home/HomePage";
 import AboutPage from "../../pages/About/AboutPage";
 import LoginPage from "../../pages/Auth/LoginPage";
@@ -6,12 +6,31 @@ import RegisterPage from "../../pages/Auth/RegisterPage";
 import DashboardPage from "../../pages/Dashboard/DashboardPage";
 import { RequireAuth } from "../../features/auth/guards";
 import NotFoundPage from "../../pages/System/NotFoundPage";
+import {useAuthStore} from "../../store/authStore.ts";
+import {Box, CircularProgress} from "@mui/material";
 
 export function RouterProvider() {
+    const { user, loading } = useAuthStore();
+
+    // shows spinner if loading
+    if (loading) {
+        return (
+            <Box
+                minHeight="100vh"
+                display="flex"
+                alignItems="center"
+                justifyContent="center"
+            >
+                <CircularProgress />
+            </Box>
+        );
+    }
+
     return (
         <BrowserRouter>
             <Routes>
                 {/* Public */}
+                <Route path="/" element={user ? <Navigate to="/app" replace /> : <HomePage />} />
                 <Route path="/" element={<HomePage />} />
                 <Route path="/about" element={<AboutPage />} />
                 <Route path="/login" element={<LoginPage />} />

--- a/frontend/src/pages/Home/HomePage.tsx
+++ b/frontend/src/pages/Home/HomePage.tsx
@@ -5,8 +5,19 @@ import AppFooter from "../../components/Layout/AppFooter";
 import RocketLaunchIcon from "@mui/icons-material/RocketLaunch";
 import SecurityIcon from "@mui/icons-material/Security";
 import DesignServicesIcon from "@mui/icons-material/DesignServices";
+import { useEffect } from "react";
+import { useNavigate } from "react-router-dom";
+import { me } from "../../features/auth/api";
 
 export default function HomePage() {
+    const navigate = useNavigate();
+
+    useEffect(() => {
+        me().then((user) => {
+            if (user) navigate("/app", { replace: true });
+        });
+    }, [navigate]);
+
     return (
         <Box sx={{ minHeight: "100vh", display: "flex", flexDirection: "column" }}>
             <SiteTopBar />

--- a/frontend/src/store/authStore.ts
+++ b/frontend/src/store/authStore.ts
@@ -1,0 +1,23 @@
+import { create } from "zustand";
+import { me, type UserDto } from "../features/auth/api";
+
+type AuthState = {
+    user: UserDto | null;
+    loading: boolean;
+    fetchUser: () => Promise<void>;
+    clear: () => void;
+};
+
+export const useAuthStore = create<AuthState>((set) => ({
+    user: null,
+    loading: true,
+    fetchUser: async () => {
+        try {
+            const u = await me();
+            set({ user: u, loading: false });
+        } catch {
+            set({ user: null, loading: false });
+        }
+    },
+    clear: () => set({ user: null }),
+}));


### PR DESCRIPTION
- added axios response interceptor to handle 401 errors:
  * calls /auth/refresh once, retries original request
  * redirects to /login if refresh fails
- introduced Zustand auth store to load user on app start
- updated router to redirect "/" to /app when user is authenticated
- added fullscreen spinner while checking auth state