### PR TITLE
fix(auth): prevent refresh after logout and ensure redirect to login

### DIFF
--- a/frontend/src/app/providers/RouterProvider.tsx
+++ b/frontend/src/app/providers/RouterProvider.tsx
@@ -1,13 +1,19 @@
-import {BrowserRouter, Routes, Route, Navigate} from "react-router-dom";
+import { BrowserRouter, Routes, Route, Navigate } from "react-router-dom";
+import type { ReactNode } from "react";
 import HomePage from "../../pages/Home/HomePage";
 import AboutPage from "../../pages/About/AboutPage";
 import LoginPage from "../../pages/Auth/LoginPage";
 import RegisterPage from "../../pages/Auth/RegisterPage";
 import DashboardPage from "../../pages/Dashboard/DashboardPage";
-import { RequireAuth } from "../../features/auth/guards";
 import NotFoundPage from "../../pages/System/NotFoundPage";
-import {useAuthStore} from "../../store/authStore.ts";
-import {Box, CircularProgress} from "@mui/material";
+import { RequireAuth } from "../../features/auth/guards";
+import { useAuthStore } from "../../store/authStore";
+import { Box, CircularProgress } from "@mui/material";
+
+function AuthGate({ children }: { children: ReactNode }) {
+    const { user } = useAuthStore();
+    return user ? <Navigate to="/app" replace /> : <>{children}</>;
+}
 
 export function RouterProvider() {
     const { user, loading } = useAuthStore();
@@ -31,10 +37,9 @@ export function RouterProvider() {
             <Routes>
                 {/* Public */}
                 <Route path="/" element={user ? <Navigate to="/app" replace /> : <HomePage />} />
-                <Route path="/" element={<HomePage />} />
                 <Route path="/about" element={<AboutPage />} />
-                <Route path="/login" element={<LoginPage />} />
-                <Route path="/register" element={<RegisterPage />} />
+                <Route path="/login" element={<AuthGate><LoginPage /></AuthGate>} />
+                <Route path="/register" element={<AuthGate><RegisterPage /></AuthGate>} />
 
                 {/* Private */}
                 <Route element={<RequireAuth />}>

--- a/frontend/src/features/auth/api.ts
+++ b/frontend/src/features/auth/api.ts
@@ -1,21 +1,20 @@
 import { api } from "../../api/client";
 
-export type UserDto = {id: string; name: string; surname?: string; email: string;};
+export type UserDto = { id: string; name: string; surname?: string; email: string; };
 
 export async function login(email: string, password: string) {
-    await api.post("/auth/login", {email, password});
+    await api.post("/auth/login", { email, password });
 }
 
 export async function register(name: string, surname: string, email: string, password: string) {
-    await api.post("/auth/register", {name, surname, email, password});
+    await api.post("/auth/register", { name, surname, email, password });
 }
 
 export async function me(): Promise<UserDto | null> {
     try {
-        const {data} = await api.get<UserDto>("/auth/me");
+        const { data } = await api.get<UserDto>("/auth/me", { skipAuthRedirect: true });
         return data;
-    }
-    catch {
+    } catch {
         return null;
     }
 }

--- a/frontend/src/features/auth/guards.tsx
+++ b/frontend/src/features/auth/guards.tsx
@@ -1,19 +1,12 @@
-import { useEffect, useState } from "react";
-import { Navigate, Outlet } from "react-router-dom";
-import { CircularProgress, Box } from "@mui/material";
-import {me} from "./api";
+import { Navigate, Outlet, useLocation } from "react-router-dom";
+import { Box, CircularProgress } from "@mui/material";
+import { useAuthStore } from "../../store/authStore";
 
 export function RequireAuth() {
-    const [status, setStatus] = useState<"loading" | "ok" | "nope">("loading");
+    const { user, loading } = useAuthStore();
+    const location = useLocation();
 
-    useEffect(() => {
-        let alive = true;
-        me().then((u)=> { if (alive) setStatus(u?"ok":"nope"); })
-            .catch(()=> { if (alive) setStatus("nope") });
-        return () => { alive = false; }
-        }, []);
-
-    if (status === "loading") {
+    if (loading) {
         return (
             <Box minHeight="60vh" display="flex" alignItems="center" justifyContent="center">
                 <CircularProgress />
@@ -21,5 +14,5 @@ export function RequireAuth() {
         );
     }
 
-    return status === "ok" ? <Outlet /> : <Navigate to="/login" replace />;
+    return user ? <Outlet /> : <Navigate to="/login" replace state={{ from: location }} />;
 }

--- a/frontend/src/pages/Auth/LoginPage.tsx
+++ b/frontend/src/pages/Auth/LoginPage.tsx
@@ -2,9 +2,12 @@ import { useState } from "react";
 import { useNavigate, Link as RouterLink } from "react-router-dom";
 import { Container, Box, Typography, TextField, Button, Alert, Stack, Link } from "@mui/material";
 import { login } from "../../features/auth/api";
+import {useAuthStore} from "../../store/authStore.ts";
 
 export default function LoginPage() {
     const navigate = useNavigate();
+    const fetchUser = useAuthStore((s) => s.fetchUser);
+
     const [email, setEmail] = useState("");
     const [password, setPassword] = useState("");
     const [submitting, setSubmitting] = useState(false);
@@ -16,6 +19,7 @@ export default function LoginPage() {
         setSubmitting(true);
         try {
             await login(email, password);
+            await fetchUser();             // <- hydrate store
             navigate("/app", { replace: true });
         } catch (err) {
             const msg = err instanceof Error ? err.message : "Login failed";

--- a/frontend/src/pages/Dashboard/DashboardPage.tsx
+++ b/frontend/src/pages/Dashboard/DashboardPage.tsx
@@ -1,8 +1,9 @@
 import { useEffect, useState } from "react";
 import { Container, Box, Typography, Button, Stack, CircularProgress } from "@mui/material";
 import { useNavigate } from "react-router-dom";
-import { me, logout, type UserDto } from "../../features/auth/api";
+import { me, type UserDto } from "../../features/auth/api";
 import MainAppBar from "../../components/AppBar/MainAppBar.tsx";
+import {useAuthStore} from "../../store/authStore.ts";
 
 
 
@@ -10,15 +11,16 @@ export default function DashboardPage() {
     const navigate = useNavigate();
     const [user, setUser] = useState<UserDto | null>(null);
     const [loading, setLoading] = useState(true);
+    const doLogout = useAuthStore(s => s.logout);
 
     useEffect(() => {
         me().then(setUser).finally(() => setLoading(false));
     }, []);
 
-    async function handleLogout() {
-        await logout();
-        navigate("/", { replace: true });
-    }
+    const handleLogout = async () => {
+        await doLogout();
+        navigate("/login", { replace: true });
+    };
 
     if (loading) {
         return (

--- a/frontend/src/pages/Home/HomePage.tsx
+++ b/frontend/src/pages/Home/HomePage.tsx
@@ -5,18 +5,8 @@ import AppFooter from "../../components/Layout/AppFooter";
 import RocketLaunchIcon from "@mui/icons-material/RocketLaunch";
 import SecurityIcon from "@mui/icons-material/Security";
 import DesignServicesIcon from "@mui/icons-material/DesignServices";
-import { useEffect } from "react";
-import { useNavigate } from "react-router-dom";
-import { me } from "../../features/auth/api";
 
 export default function HomePage() {
-    const navigate = useNavigate();
-
-    useEffect(() => {
-        me().then((user) => {
-            if (user) navigate("/app", { replace: true });
-        });
-    }, [navigate]);
 
     return (
         <Box sx={{ minHeight: "100vh", display: "flex", flexDirection: "column" }}>

--- a/frontend/src/store/authStore.ts
+++ b/frontend/src/store/authStore.ts
@@ -1,11 +1,13 @@
 import { create } from "zustand";
-import { me, type UserDto } from "../features/auth/api";
+import { me, logout as apiLogout, type UserDto } from "../features/auth/api";
+import { setLoggingOut } from "../api/client";
 
 type AuthState = {
     user: UserDto | null;
     loading: boolean;
     fetchUser: () => Promise<void>;
     clear: () => void;
+    logout: () => Promise<void>;
 };
 
 export const useAuthStore = create<AuthState>((set) => ({
@@ -20,4 +22,12 @@ export const useAuthStore = create<AuthState>((set) => ({
         }
     },
     clear: () => set({ user: null }),
+    logout: async () => {
+        try {
+            setLoggingOut(true);
+            await apiLogout();
+        } finally {
+            set({ user: null });
+        }
+    },
 }));

--- a/frontend/src/types/axios.d.ts
+++ b/frontend/src/types/axios.d.ts
@@ -1,0 +1,8 @@
+import "axios";
+
+declare module "axios" {
+    interface AxiosRequestConfig {
+        _retry?: boolean;
+        skipAuthRedirect?: boolean;
+    }
+}


### PR DESCRIPTION
- Added logout guard in axios interceptor to block token refresh while logging out
- Updated auth store to set `user=null` and mark logout state before calling API
- Ensured dashboard logout button navigates reliably to /login
- Fixed issue where user stayed on /app after logout due to refresh race