### PR TITLE
Refactor/login-register-pages

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -12,6 +12,7 @@
         "@emotion/styled": "^11.14.1",
         "@hookform/resolvers": "^5.2.1",
         "@mui/icons-material": "^7.3.2",
+        "@mui/lab": "^7.0.0-beta.17",
         "@mui/material": "^7.3.2",
         "axios": "^1.11.0",
         "react": "^19.1.1",
@@ -1222,6 +1223,50 @@
         "react": "^17.0.0 || ^18.0.0 || ^19.0.0"
       },
       "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@mui/lab": {
+      "version": "7.0.0-beta.17",
+      "resolved": "https://registry.npmjs.org/@mui/lab/-/lab-7.0.0-beta.17.tgz",
+      "integrity": "sha512-H8tSINm6Xgbi7o49MplAwks4tAEE6SpFNd9l7n4NURl0GSpOv0CZvgXKSJt4+6TmquDhE7pomHpHWJiVh/2aCg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.28.3",
+        "@mui/system": "^7.3.2",
+        "@mui/types": "^7.4.6",
+        "@mui/utils": "^7.3.2",
+        "clsx": "^2.1.1",
+        "prop-types": "^15.8.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mui-org"
+      },
+      "peerDependencies": {
+        "@emotion/react": "^11.5.0",
+        "@emotion/styled": "^11.3.0",
+        "@mui/material": "^7.3.2",
+        "@mui/material-pigment-css": "^7.3.2",
+        "@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react": "^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@emotion/react": {
+          "optional": true
+        },
+        "@emotion/styled": {
+          "optional": true
+        },
+        "@mui/material-pigment-css": {
+          "optional": true
+        },
         "@types/react": {
           "optional": true
         }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -14,6 +14,7 @@
     "@emotion/styled": "^11.14.1",
     "@hookform/resolvers": "^5.2.1",
     "@mui/icons-material": "^7.3.2",
+    "@mui/lab": "^7.0.0-beta.17",
     "@mui/material": "^7.3.2",
     "axios": "^1.11.0",
     "react": "^19.1.1",

--- a/frontend/src/features/auth/components/AuthLayout.tsx
+++ b/frontend/src/features/auth/components/AuthLayout.tsx
@@ -1,0 +1,35 @@
+import {Container, Box, Typography, Link, Stack} from "@mui/material";
+import { Link as RouterLink } from "react-router-dom";
+import Logo from "../../../assets/icon_2.svg";
+
+type Props = {
+    title: string;
+    subtitle?: string;
+    children: React.ReactNode
+};
+
+export default function AuthLayout({ title, subtitle, children }: Props) {
+    return (
+        <Container maxWidth="xs">
+            <Box py={8} display="flex" flexDirection="column" alignItems="center">
+                <Link component={RouterLink} to="/" underline="none" sx={{ mb: 2 }}>
+                    <Stack direction="row" spacing={1.5} alignItems="center">
+                        <img src={Logo} alt="TaskRaum logo" width={40} height={40} />
+                        <Typography variant="h5" fontWeight={800}>TaskRaum</Typography>
+                    </Stack>
+                </Link>
+
+                <Typography variant="h4" fontWeight={700} mb={1} textAlign="center">
+                    {title}
+                </Typography>
+                {subtitle && (
+                    <Typography color="text.secondary" mb={3} textAlign="center">
+                        {subtitle}
+                    </Typography>
+                )}
+
+                <Box width="100%">{children}</Box>
+            </Box>
+        </Container>
+    );
+}

--- a/frontend/src/features/auth/components/FormErrorAlert.tsx
+++ b/frontend/src/features/auth/components/FormErrorAlert.tsx
@@ -1,0 +1,6 @@
+import { Alert } from "@mui/material";
+
+export default function FormErrorAlert({ message }: { message: string | null }) {
+    if (!message) return null;
+    return <Alert severity="error" sx={{ mb: 2 }}>{message}</Alert>;
+}

--- a/frontend/src/features/auth/components/PasswordField.tsx
+++ b/frontend/src/features/auth/components/PasswordField.tsx
@@ -1,0 +1,58 @@
+import { useState } from "react";
+import { Controller } from "react-hook-form";
+import type {Control, FieldValues, Path} from "react-hook-form";
+import {
+    TextField,
+    InputAdornment,
+    IconButton,
+} from "@mui/material";
+import Visibility from "@mui/icons-material/Visibility";
+import VisibilityOff from "@mui/icons-material/VisibilityOff";
+
+type Props<T extends FieldValues> = {
+    control: Control<T>;
+    name: Path<T>;
+    label?: string;
+    autoFocus?: boolean;
+    autoComplete?: string;
+};
+
+export default function PasswordField<T extends FieldValues>({
+                                                                 control, name, label = "Password", autoFocus, autoComplete,
+                                                             }: Props<T>) {
+    const [show, setShow] = useState(false);
+
+    return (
+        <Controller
+            control={control}
+            name={name}
+            render={({ field, fieldState }) => (
+                <TextField
+                    {...field}
+                    type={show ? "text" : "password"}
+                    label={label}
+                    autoFocus={!!autoFocus}
+                    error={!!fieldState.error}
+                    helperText={fieldState.error?.message}
+                    fullWidth
+                    slotProps={{
+                        input: {
+                            ...(autoComplete ? { autoComplete } : {}),
+                            endAdornment: (
+                                <InputAdornment position="end">
+                                    <IconButton
+                                        aria-label={show ? "Hide password" : "Show password"}
+                                        onClick={() => setShow(s => !s)}
+                                        edge="end"
+                                    >
+                                        {show ? <VisibilityOff /> : <Visibility />}
+                                    </IconButton>
+                                </InputAdornment>
+                            ),
+                        },
+                    }}
+                />
+            )}
+        />
+    );
+}

--- a/frontend/src/features/auth/validation.ts
+++ b/frontend/src/features/auth/validation.ts
@@ -1,0 +1,22 @@
+import { z } from "zod";
+
+export const loginSchema = z.object({
+    email: z.email("Enter a valid email"),
+    password: z.string().min(1, "Password is required"),
+});
+
+const PASSWORD_RULE = /^(?=.*[A-Z])(?=.*\d).{8,}$/;
+
+export const registerSchema = z.object({
+    name: z.string().min(2, "Min. 2 characters"),
+    surname: z.string().min(2, "Min. 2 characters"),
+    email: z.email("Enter a valid email"),
+    password: z.string().regex(PASSWORD_RULE, "Min 8, 1 uppercase, 1 number"),
+    confirmPassword: z.string(),
+}).refine(v => v.password === v.confirmPassword, {
+    message: "Passwords do not match",
+    path: ["confirmPassword"],
+});
+
+export type LoginInput = z.infer<typeof loginSchema>;
+export type RegisterInput = z.infer<typeof registerSchema>;


### PR DESCRIPTION
Migrated LoginPage & RegisterPage to RHF + Zod 4.1

Added AuthLayout with TaskRaum logo/title

Added reusable PasswordField (show/hide) and FormErrorAlert

Improved backend error parsing (401, 409) → friendly messages

Register: confirm password, password hint

Login: simplified validation (no length check)