### PR TITLE
Feat/tasks api

### DIFF
--- a/backend/src/main/java/dev/taskraum/backend/common/GlobalExceptionHandler.java
+++ b/backend/src/main/java/dev/taskraum/backend/common/GlobalExceptionHandler.java
@@ -8,6 +8,8 @@ import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.server.ResponseStatusException;
 
+import java.util.Objects;
+
 @RestControllerAdvice
 public class GlobalExceptionHandler {
 
@@ -33,13 +35,14 @@ public class GlobalExceptionHandler {
 
     @ExceptionHandler(IllegalArgumentException.class)
     public ResponseEntity<ApiError> handleIllegalArgument(IllegalArgumentException ex) {
-        String code = ex.getMessage();
-        HttpStatus status = (code != null && code.endsWith("_NOT_FOUND")) ? HttpStatus.NOT_FOUND : HttpStatus.BAD_REQUEST;
+        String code = Objects.toString(ex.getMessage(), "");
+        HttpStatus status = code.endsWith("_NOT_FOUND") ? HttpStatus.NOT_FOUND : HttpStatus.BAD_REQUEST;
         String error = (status == HttpStatus.NOT_FOUND) ? "NotFound" : "BadRequest";
         String message = switch (code) {
             case "PROJECT_NOT_FOUND" -> "Project not found";
             case "TASK_NOT_FOUND"    -> "Task not found";
-            default                  -> code != null ? code : "Bad request.";
+            case ""                  -> "Bad request.";
+            default                  -> code;
         };
         return ResponseEntity.status(status).body(ApiError.of(error, message, status.value()));
     }

--- a/backend/src/main/java/dev/taskraum/backend/common/GlobalExceptionHandler.java
+++ b/backend/src/main/java/dev/taskraum/backend/common/GlobalExceptionHandler.java
@@ -33,11 +33,15 @@ public class GlobalExceptionHandler {
 
     @ExceptionHandler(IllegalArgumentException.class)
     public ResponseEntity<ApiError> handleIllegalArgument(IllegalArgumentException ex) {
-        var msg = ex.getMessage();
-        HttpStatus status = "PROJECT_NOT_FOUND".equals(msg) ? HttpStatus.NOT_FOUND : HttpStatus.BAD_REQUEST;
-        var error = "PROJECT_NOT_FOUND".equals(msg) ? "NotFound" : "BadRequest";
-        return ResponseEntity.status(status)
-                .body(ApiError.of(error, msg, status.value()));
+        String code = ex.getMessage();
+        HttpStatus status = (code != null && code.endsWith("_NOT_FOUND")) ? HttpStatus.NOT_FOUND : HttpStatus.BAD_REQUEST;
+        String error = (status == HttpStatus.NOT_FOUND) ? "NotFound" : "BadRequest";
+        String message = switch (code) {
+            case "PROJECT_NOT_FOUND" -> "Project not found";
+            case "TASK_NOT_FOUND"    -> "Task not found";
+            default                  -> code != null ? code : "Bad request.";
+        };
+        return ResponseEntity.status(status).body(ApiError.of(error, message, status.value()));
     }
 
     @ExceptionHandler(IllegalStateException.class)

--- a/backend/src/main/java/dev/taskraum/backend/common/enums/TaskPriority.java
+++ b/backend/src/main/java/dev/taskraum/backend/common/enums/TaskPriority.java
@@ -1,0 +1,5 @@
+package dev.taskraum.backend.common.enums;
+
+public enum TaskPriority {
+    LOW, MEDIUM, HIGH
+}

--- a/backend/src/main/java/dev/taskraum/backend/common/enums/TaskStatus.java
+++ b/backend/src/main/java/dev/taskraum/backend/common/enums/TaskStatus.java
@@ -1,0 +1,5 @@
+package dev.taskraum.backend.common.enums;
+
+public enum TaskStatus {
+    TODO, IN_PROGRESS, DONE
+}

--- a/backend/src/main/java/dev/taskraum/backend/projects/ProjectService.java
+++ b/backend/src/main/java/dev/taskraum/backend/projects/ProjectService.java
@@ -4,6 +4,7 @@ import dev.taskraum.backend.common.enums.ProjectStatus;
 import dev.taskraum.backend.projects.dto.CreateProjectDto;
 import dev.taskraum.backend.projects.dto.ProjectResponse;
 import dev.taskraum.backend.projects.dto.UpdateProjectDto;
+import dev.taskraum.backend.tasks.TaskRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -14,7 +15,7 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class ProjectService {
     private final ProjectRepository projectRepo;
-    // taskRepo for delete
+    private final TaskRepository taskRepo;
 
     public Page<ProjectResponse> list(String ownerId, ProjectStatus status, Pageable pageable) {
         return projectRepo.findByOwnerIdAndStatus(ownerId, status, pageable).map(this::toResponse);
@@ -64,7 +65,7 @@ public class ProjectService {
         Project p = projectRepo.findByIdAndOwnerId(id, ownerId)
                 .orElseThrow(() -> new IllegalArgumentException("PROJECT_NOT_FOUND"));
 
-        // taskRepo delete Orphan Tasks with id(Project)
+        taskRepo.deleteByProjectId(p.getId());
 
         projectRepo.delete(p);
     }

--- a/backend/src/main/java/dev/taskraum/backend/tasks/Task.java
+++ b/backend/src/main/java/dev/taskraum/backend/tasks/Task.java
@@ -1,0 +1,41 @@
+package dev.taskraum.backend.tasks;
+
+import dev.taskraum.backend.common.enums.TaskPriority;
+import dev.taskraum.backend.common.enums.TaskStatus;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.mongodb.core.index.CompoundIndex;
+import org.springframework.data.mongodb.core.index.CompoundIndexes;
+import org.springframework.data.mongodb.core.index.Indexed;
+import org.springframework.data.mongodb.core.mapping.Document;
+
+import java.time.Instant;
+
+@Document("tasks")
+@Data @Builder @AllArgsConstructor @NoArgsConstructor
+@CompoundIndexes({
+    @CompoundIndex(name = "proj_status_order_idx", def = "{'projectId':1,'status':1,'order':1}")
+})
+public class Task {
+    @Id private String id;
+
+    @Indexed private String projectId;
+
+    private String title;
+    private String description;
+
+    @Indexed private TaskStatus status;
+    @Indexed private Integer order;
+    private TaskPriority priority;
+
+    private Instant dueDate;
+    private String assigneeId;
+
+    @CreatedDate private Instant createdAt;
+    @LastModifiedDate private Instant updatedAt;
+}

--- a/backend/src/main/java/dev/taskraum/backend/tasks/TaskController.java
+++ b/backend/src/main/java/dev/taskraum/backend/tasks/TaskController.java
@@ -1,0 +1,59 @@
+package dev.taskraum.backend.tasks;
+
+import dev.taskraum.backend.common.enums.TaskStatus;
+import dev.taskraum.backend.security.UserPrincipal;
+import dev.taskraum.backend.tasks.dto.CreateTaskDto;
+import dev.taskraum.backend.tasks.dto.TaskResponse;
+import dev.taskraum.backend.tasks.dto.UpdateTaskDto;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api")
+public class TaskController {
+    private final TaskService service;
+
+    // Column listing (one call per column)
+    @GetMapping("/projects/{projectId}/tasks")
+    public List<TaskResponse> list(
+            @AuthenticationPrincipal UserPrincipal me,
+            @PathVariable String projectId,
+            @RequestParam TaskStatus status) {
+        return service.list(me.id(), projectId, status);
+    }
+
+    @PostMapping("/projects/{projectId}/tasks")
+    public ResponseEntity<TaskResponse> create(
+            @AuthenticationPrincipal UserPrincipal me,
+            @PathVariable String projectId,
+            @RequestBody @Valid CreateTaskDto dto
+            ) {
+        var res = service.create(me.id(), projectId, dto);
+        return ResponseEntity.status(HttpStatus.CREATED).body(res);
+    }
+
+    @PutMapping("/tasks/{id}")
+    public TaskResponse update(
+            @AuthenticationPrincipal UserPrincipal me,
+            @PathVariable String id,
+            @RequestBody @Valid UpdateTaskDto dto
+    ) {
+        return service.update(me.id(), id, dto);
+    }
+
+    @DeleteMapping("/tasks/{id}")
+    public ResponseEntity<Void> delete(
+            @AuthenticationPrincipal UserPrincipal me,
+            @PathVariable String id
+    ) {
+        service.delete(me.id(), id);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/backend/src/main/java/dev/taskraum/backend/tasks/TaskRepository.java
+++ b/backend/src/main/java/dev/taskraum/backend/tasks/TaskRepository.java
@@ -1,0 +1,12 @@
+package dev.taskraum.backend.tasks;
+
+import dev.taskraum.backend.common.enums.TaskStatus;
+import org.springframework.data.mongodb.repository.MongoRepository;
+
+import java.util.List;
+
+public interface TaskRepository extends MongoRepository<Task, String> {
+    List<Task> findByProjectIdAndStatusOrderByOrderAsc(String projectId, TaskStatus status);
+    Task findTopByProjectIdAndStatusOrderByOrderDesc(String projectId, TaskStatus status);
+    void deleteByProjectId(String projectId);
+}

--- a/backend/src/main/java/dev/taskraum/backend/tasks/TaskService.java
+++ b/backend/src/main/java/dev/taskraum/backend/tasks/TaskService.java
@@ -1,0 +1,128 @@
+package dev.taskraum.backend.tasks;
+
+import dev.taskraum.backend.common.enums.ProjectStatus;
+import dev.taskraum.backend.common.enums.TaskPriority;
+import dev.taskraum.backend.common.enums.TaskStatus;
+import dev.taskraum.backend.projects.Project;
+import dev.taskraum.backend.projects.ProjectRepository;
+import dev.taskraum.backend.tasks.dto.CreateTaskDto;
+import dev.taskraum.backend.tasks.dto.TaskResponse;
+import dev.taskraum.backend.tasks.dto.UpdateTaskDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class TaskService {
+    private final TaskRepository taskRepo;
+    private final ProjectRepository projectRepo;
+
+
+    // --- Helpers --- //
+
+    private Project requireOwnedProject(String ownerId, String projectId) {
+        return projectRepo.findByIdAndOwnerId(projectId, ownerId)
+                .orElseThrow(() -> new IllegalArgumentException("PROJECT_NOT_FOUND"));
+    }
+
+    private void ensureNotArchived(Project project) {
+        if (project.getStatus() == ProjectStatus.ARCHIVED) {
+            throw new IllegalStateException("PROJECT_ARCHIVED_READ_ONLY");
+        }
+    }
+
+    private int nextOrder(String projectId, TaskStatus status) {
+        Task last = taskRepo.findTopByProjectIdAndStatusOrderByOrderDesc(projectId, status);
+        return (last == null) ? 100 : last.getOrder() + 100;
+    }
+
+    private TaskResponse toResponse(Task task) {
+        return TaskResponse.builder()
+                .id(task.getId())
+                .projectId(task.getProjectId())
+                .title(task.getTitle())
+                .description(task.getDescription())
+                .status(task.getStatus())
+                .order(task.getOrder())
+                .priority(task.getPriority())
+                .dueDate(task.getDueDate())
+                .assigneeId(task.getAssigneeId())
+                .createdAt(task.getCreatedAt())
+                .updatedAt(task.getUpdatedAt())
+                .build();
+    }
+
+    // --- API --- //
+
+    public List<TaskResponse> list(String ownerId, String projectId, TaskStatus status) {
+        requireOwnedProject(ownerId, projectId);
+        return taskRepo.findByProjectIdAndStatusOrderByOrderAsc(projectId, status)
+                .stream().map(this::toResponse).toList();
+    }
+
+    @Transactional
+    public TaskResponse create(String ownerId, String projectId, CreateTaskDto dto) {
+        var project =  requireOwnedProject(ownerId, projectId);
+        ensureNotArchived(project);
+
+        TaskStatus status = dto.getStatus() != null ? dto.getStatus() : TaskStatus.TODO;
+        int order =  dto.getOrder() != null ? dto.getOrder() : nextOrder(projectId, status);
+
+        Task task = Task.builder()
+                .projectId(project.getId())
+                .title(dto.getTitle().trim())
+                .description(dto.getDescription())
+                .status(status)
+                .order(order)
+                .priority(dto.getPriority() != null ? dto.getPriority() : TaskPriority.MEDIUM)
+                .dueDate(dto.getDueDate())
+                .assigneeId(dto.getAssigneeId())
+                .build();
+
+        return toResponse(taskRepo.save(task));
+    }
+
+    @Transactional
+    public TaskResponse update(String ownerId, String taskId, UpdateTaskDto dto) {
+        Task task = taskRepo.findById(taskId)
+                .orElseThrow(() -> new IllegalArgumentException("TASK_NOT_FOUND"));
+
+        var project = projectRepo.findByIdAndOwnerId(task.getProjectId(), ownerId)
+                .orElseThrow(() -> new IllegalArgumentException("PROJECT_NOT_FOUND"));
+        ensureNotArchived(project);
+
+        TaskStatus currentStatus = task.getStatus();
+        TaskStatus newStatus = dto.getStatus() !=  null ? dto.getStatus() : currentStatus;
+
+        if (dto.getStatus() != null) task.setStatus(newStatus);
+
+        // Order logic: if not provided and column changes, append to end of target column
+        if (dto.getOrder() != null) {
+            task.setOrder(dto.getOrder());
+        } else if (newStatus != currentStatus) {
+            task.setOrder(nextOrder(task.getProjectId(), newStatus));
+        }
+
+        if (dto.getTitle() != null) task.setTitle(dto.getTitle().trim());
+        if (dto.getDescription() != null) task.setDescription(dto.getDescription());
+        if (dto.getPriority() != null) task.setPriority(dto.getPriority());
+        if (dto.getDueDate() != null) task.setDueDate(dto.getDueDate());
+        if (dto.getAssigneeId() != null) task.setAssigneeId(dto.getAssigneeId());
+
+        return toResponse(taskRepo.save(task));
+    }
+
+    @Transactional
+    public void delete(String ownerId, String taskId) {
+        Task task = taskRepo.findById(taskId)
+                .orElseThrow(() -> new IllegalArgumentException("TASK_NOT_FOUND"));
+
+        projectRepo.findByIdAndOwnerId(task.getProjectId(), ownerId)
+                .orElseThrow(() -> new IllegalArgumentException("PROJECT_NOT_FOUND"));
+
+        taskRepo.delete(task);
+    }
+}

--- a/backend/src/main/java/dev/taskraum/backend/tasks/dto/CreateTaskDto.java
+++ b/backend/src/main/java/dev/taskraum/backend/tasks/dto/CreateTaskDto.java
@@ -1,0 +1,24 @@
+package dev.taskraum.backend.tasks.dto;
+
+import dev.taskraum.backend.common.enums.TaskPriority;
+import dev.taskraum.backend.common.enums.TaskStatus;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.Data;
+
+import java.time.Instant;
+
+@Data
+public class CreateTaskDto {
+    @NotBlank @Size(min = 1, max = 160)
+    private String title;
+
+    @Size(max = 4000)
+    private String description;
+
+    private TaskStatus status;
+    private Integer order;
+    private TaskPriority priority;
+    private Instant dueDate;
+    private String assigneeId;
+}

--- a/backend/src/main/java/dev/taskraum/backend/tasks/dto/TaskResponse.java
+++ b/backend/src/main/java/dev/taskraum/backend/tasks/dto/TaskResponse.java
@@ -1,0 +1,24 @@
+package dev.taskraum.backend.tasks.dto;
+
+import dev.taskraum.backend.common.enums.TaskPriority;
+import dev.taskraum.backend.common.enums.TaskStatus;
+import lombok.Builder;
+import lombok.Value;
+
+import java.time.Instant;
+
+@Value
+@Builder
+public class TaskResponse {
+    String id;
+    String projectId;
+    String title;
+    String description;
+    TaskStatus status;
+    Integer order;
+    TaskPriority priority;
+    Instant dueDate;
+    String assigneeId;
+    Instant createdAt;
+    Instant updatedAt;
+}

--- a/backend/src/main/java/dev/taskraum/backend/tasks/dto/UpdateTaskDto.java
+++ b/backend/src/main/java/dev/taskraum/backend/tasks/dto/UpdateTaskDto.java
@@ -1,0 +1,24 @@
+package dev.taskraum.backend.tasks.dto;
+
+import dev.taskraum.backend.common.enums.TaskPriority;
+import dev.taskraum.backend.common.enums.TaskStatus;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.Data;
+
+import java.time.Instant;
+
+@Data
+public class UpdateTaskDto {
+    @NotBlank @Size(min = 1, max = 160)
+    private String title;
+
+    @Size(max = 4000)
+    private String description;
+
+    private TaskStatus status;
+    private Integer order;
+    private TaskPriority priority;
+    private Instant dueDate;
+    private String assigneeId;
+}

--- a/backend/src/test/java/dev/taskraum/backend/common/GlobalExceptionHandlerTest.java
+++ b/backend/src/test/java/dev/taskraum/backend/common/GlobalExceptionHandlerTest.java
@@ -35,8 +35,17 @@ class GlobalExceptionHandlerTest {
         var res = handler.handleIllegalArgument(new IllegalArgumentException("PROJECT_NOT_FOUND"));
         assertThat(res.getStatusCode()).isEqualTo(HttpStatus.NOT_FOUND);
         Assertions.assertNotNull(res.getBody());
-        assertThat(res.getBody().error()).isEqualTo("NotFound");     // adapt getters (e.g., getCode())
+        assertThat(res.getBody().error()).isEqualTo("NotFound");
         assertThat(res.getBody().message()).isEqualTo("Project not found");
+    }
+
+    @Test
+    void handleIllegalArgument_notFoundWhenTaskNotFound() {
+        var res = handler.handleIllegalArgument(new IllegalArgumentException("TASK_NOT_FOUND"));
+        assertThat(res.getStatusCode()).isEqualTo(HttpStatus.NOT_FOUND);
+        assertThat(res.getBody()).isNotNull();
+        assertThat(res.getBody().error()).isEqualTo("NotFound");
+        assertThat(res.getBody().message()).isEqualTo("Task not found");
     }
 
     @Test

--- a/backend/src/test/java/dev/taskraum/backend/common/GlobalExceptionHandlerTest.java
+++ b/backend/src/test/java/dev/taskraum/backend/common/GlobalExceptionHandlerTest.java
@@ -36,7 +36,7 @@ class GlobalExceptionHandlerTest {
         assertThat(res.getStatusCode()).isEqualTo(HttpStatus.NOT_FOUND);
         Assertions.assertNotNull(res.getBody());
         assertThat(res.getBody().error()).isEqualTo("NotFound");     // adapt getters (e.g., getCode())
-        assertThat(res.getBody().message()).isEqualTo("PROJECT_NOT_FOUND");
+        assertThat(res.getBody().message()).isEqualTo("Project not found");
     }
 
     @Test

--- a/backend/src/test/java/dev/taskraum/backend/projects/ProjectServiceTest.java
+++ b/backend/src/test/java/dev/taskraum/backend/projects/ProjectServiceTest.java
@@ -4,6 +4,7 @@ import dev.taskraum.backend.common.enums.ProjectStatus;
 import dev.taskraum.backend.projects.dto.CreateProjectDto;
 import dev.taskraum.backend.projects.dto.ProjectResponse;
 import dev.taskraum.backend.projects.dto.UpdateProjectDto;
+import dev.taskraum.backend.tasks.TaskRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
@@ -25,12 +26,13 @@ import static org.mockito.Mockito.*;
 class ProjectServiceTest {
 
     @Mock private ProjectRepository projectRepo;
+    @Mock private TaskRepository taskRepo;
     private ProjectService service;
 
     @BeforeEach
     void setUp() {
         MockitoAnnotations.openMocks(this);
-        service = new ProjectService(projectRepo);
+        service = new ProjectService(projectRepo,  taskRepo);
     }
 
     @Test

--- a/backend/src/test/java/dev/taskraum/backend/tasks/TaskControllerTest.java
+++ b/backend/src/test/java/dev/taskraum/backend/tasks/TaskControllerTest.java
@@ -1,0 +1,151 @@
+package dev.taskraum.backend.tasks;
+
+
+import dev.taskraum.backend.common.enums.TaskStatus;
+import dev.taskraum.backend.security.UserPrincipal;
+import dev.taskraum.backend.tasks.dto.CreateTaskDto;
+import dev.taskraum.backend.tasks.dto.TaskResponse;
+import dev.taskraum.backend.tasks.dto.UpdateTaskDto;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.http.MediaType;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.time.Instant;
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(TaskController.class)
+@ActiveProfiles("test")
+@AutoConfigureMockMvc(addFilters = false)
+class TaskControllerTest {
+
+    @Autowired private MockMvc mvc;
+    @MockitoBean TaskService service;
+
+    @BeforeEach
+    void setAuth() {
+        var auth = new UsernamePasswordAuthenticationToken(
+                new UserPrincipal("u1", "user@example.com"),
+                null,
+                List.of(new SimpleGrantedAuthority("ROLE_USER")));
+        SecurityContextHolder.getContext().setAuthentication(auth);
+    }
+
+    @AfterEach void clear() {SecurityContextHolder.clearContext();}
+
+    private TaskResponse resp(String id) {
+        return TaskResponse.builder()
+                .id(id).projectId("p1").title("T").status(TaskStatus.TODO)
+                .order(100).createdAt(Instant.now()).updatedAt(Instant.now()).build();
+    }
+
+    @Test
+    void list_ok_returnsArray() throws Exception {
+        var auth = SecurityContextHolder.getContext().getAuthentication();
+        when(service.list("u1", "p1", TaskStatus.TODO))
+                .thenReturn(List.of(resp("t1"), resp("t2")));
+
+        mvc.perform(get("/api/projects/{pid}/tasks", "p1")
+                        .param("status", "TODO")
+                .with(authentication(auth)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$[0].id").value("t1"))
+                .andExpect(jsonPath("$[1].id").value("t2"));
+    }
+
+    @Test
+    void list_missingStatus_returns400() throws Exception {
+        var auth = SecurityContextHolder.getContext().getAuthentication();
+        mvc.perform(get("/api/projects/{pid}/tasks", "p1")
+                .with(authentication(auth)))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void create_valid_returns201() throws Exception {
+        var auth = SecurityContextHolder.getContext().getAuthentication();
+        when(service.create(eq("u1"), eq("p1"), any(CreateTaskDto.class)))
+                .thenReturn(resp("t1"));
+
+        var body = """
+                 {"title":"New task","description":"d"}
+                """;
+
+        mvc.perform(post("/api/projects/{pid}/tasks", "p1")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(body))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.id").value("t1"));
+    }
+
+    @Test
+    void create_invalidTitle_returns400() throws Exception {
+        var auth = SecurityContextHolder.getContext().getAuthentication();
+        var body = """
+                {"title":"  "}
+                """;
+        mvc.perform(post("/api/projects/{pid}/tasks", "p1")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body)
+                        .with(authentication(auth)))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void update_ok_returns200() throws Exception {
+        var auth = SecurityContextHolder.getContext().getAuthentication();
+        when(service.update(eq("u1"), eq("t1"), any(UpdateTaskDto.class)))
+                .thenReturn(resp("t1"));
+
+        var body = """
+                {"title":"Renamed"}
+                """;
+
+        mvc.perform(put("/api/tasks/{id}", "t1")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(body)
+                .with(authentication(auth)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.id").value("t1"));
+    }
+
+    @Test
+    void update_invalidTitle_returns400() throws Exception {
+        var auth = SecurityContextHolder.getContext().getAuthentication();
+        var body = """
+                {"title": ""}
+                """;
+        mvc.perform(put("/api/tasks/{id}", "t1")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(body)
+                .with(authentication(auth)))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void delete_noContent()  throws Exception {
+        var auth = SecurityContextHolder.getContext().getAuthentication();
+        mvc.perform(delete("/api/tasks/{id}", "t1")
+                .with(authentication(auth)))
+                .andExpect(status().isNoContent());
+        verify(service).delete("u1", "t1");
+    }
+}

--- a/backend/src/test/java/dev/taskraum/backend/tasks/TaskControllerTest.java
+++ b/backend/src/test/java/dev/taskraum/backend/tasks/TaskControllerTest.java
@@ -91,7 +91,8 @@ class TaskControllerTest {
 
         mvc.perform(post("/api/projects/{pid}/tasks", "p1")
                 .contentType(MediaType.APPLICATION_JSON)
-                .content(body))
+                .content(body)
+                .with(authentication(auth)))
                 .andExpect(status().isCreated())
                 .andExpect(jsonPath("$.id").value("t1"));
     }

--- a/backend/src/test/java/dev/taskraum/backend/tasks/TaskRepositoryTest.java
+++ b/backend/src/test/java/dev/taskraum/backend/tasks/TaskRepositoryTest.java
@@ -1,0 +1,58 @@
+package dev.taskraum.backend.tasks;
+
+import dev.taskraum.backend.common.enums.TaskPriority;
+import dev.taskraum.backend.common.enums.TaskStatus;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.data.mongo.DataMongoTest;
+
+import java.time.Instant;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DataMongoTest
+class TaskRepositoryTest {
+
+    @Autowired private TaskRepository repo;
+
+    private Task task(String id, String projectId, TaskStatus status, int order) {
+        return Task.builder()
+                .id(id)
+                .projectId(projectId)
+                .title("T-" + id)
+                .status(status)
+                .order(order)
+                .priority(TaskPriority.MEDIUM)
+                .createdAt(Instant.now())
+                .updatedAt(Instant.now())
+                .build();
+    }
+
+    @Test
+    void findByProjectIdAndStatusOrderByOrderAsc_returnsOrderedTasks() {
+        repo.saveAll(List.of(
+                task("t1","p1",TaskStatus.TODO, 300),
+                task("t2","p1",TaskStatus.TODO, 100),
+                task("t3","p1",TaskStatus.TODO, 200)
+                ));
+
+        List<Task> result = repo.findByProjectIdAndStatusOrderByOrderAsc("p1", TaskStatus.TODO);
+
+        assertThat(result).extracting(Task::getId).containsExactly("t2", "t3", "t1");
+    }
+
+    @Test
+    void findTopByProjectIdAndStatusOrderByOrderDesc_returnsHighestOrder() {
+        repo.saveAll(List.of(
+                task("t1", "p1", TaskStatus.IN_PROGRESS, 100),
+                task("t2", "p1", TaskStatus.IN_PROGRESS, 500),
+                task("t3", "p1", TaskStatus.IN_PROGRESS, 300)
+        ));
+
+        Task last = repo.findTopByProjectIdAndStatusOrderByOrderDesc("p1", TaskStatus.IN_PROGRESS);
+
+        assertThat(last.getId()).isEqualTo("t2");
+        assertThat(last.getOrder()).isEqualTo(500);
+    }
+}

--- a/backend/src/test/java/dev/taskraum/backend/tasks/TaskRepositoryTest.java
+++ b/backend/src/test/java/dev/taskraum/backend/tasks/TaskRepositoryTest.java
@@ -45,12 +45,12 @@ class TaskRepositoryTest {
     @Test
     void findTopByProjectIdAndStatusOrderByOrderDesc_returnsHighestOrder() {
         repo.saveAll(List.of(
-                task("t1", "p1", TaskStatus.IN_PROGRESS, 100),
-                task("t2", "p1", TaskStatus.IN_PROGRESS, 500),
-                task("t3", "p1", TaskStatus.IN_PROGRESS, 300)
+                task("t1", "p2", TaskStatus.IN_PROGRESS, 100),
+                task("t2", "p2", TaskStatus.IN_PROGRESS, 500),
+                task("t3", "p2", TaskStatus.IN_PROGRESS, 300)
         ));
 
-        Task last = repo.findTopByProjectIdAndStatusOrderByOrderDesc("p1", TaskStatus.IN_PROGRESS);
+        Task last = repo.findTopByProjectIdAndStatusOrderByOrderDesc("p2", TaskStatus.IN_PROGRESS);
 
         assertThat(last.getId()).isEqualTo("t2");
         assertThat(last.getOrder()).isEqualTo(500);

--- a/backend/src/test/java/dev/taskraum/backend/tasks/TaskServiceTest.java
+++ b/backend/src/test/java/dev/taskraum/backend/tasks/TaskServiceTest.java
@@ -1,0 +1,265 @@
+package dev.taskraum.backend.tasks;
+
+import dev.taskraum.backend.common.enums.ProjectStatus;
+import dev.taskraum.backend.common.enums.TaskPriority;
+import dev.taskraum.backend.common.enums.TaskStatus;
+import dev.taskraum.backend.projects.Project;
+import dev.taskraum.backend.projects.ProjectRepository;
+import dev.taskraum.backend.tasks.dto.CreateTaskDto;
+import dev.taskraum.backend.tasks.dto.TaskResponse;
+import dev.taskraum.backend.tasks.dto.UpdateTaskDto;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+class TaskServiceTest {
+
+    TaskRepository taskRepo;
+    ProjectRepository projectRepo;
+    TaskService service;
+
+    @BeforeEach
+    void setUp() {
+        taskRepo = mock(TaskRepository.class);
+        projectRepo = mock(ProjectRepository.class);
+        service = new TaskService(taskRepo, projectRepo);
+    }
+
+    // --- Helpers --- //
+
+    private Project project(String id, ProjectStatus status) {
+        return Project.builder()
+                .id(id)
+                .ownerId("u1")
+                .title("Demo project")
+                .status(status)
+                .createdAt(Instant.now())
+                .updatedAt(Instant.now())
+                .build();
+    }
+
+    private Task task(String id, String projectId, TaskStatus status, int order) {
+        return Task.builder()
+                .id(id).projectId(projectId)
+                .title("Title").description("Desc")
+                .status(status).order(order)
+                .priority(TaskPriority.MEDIUM)
+                .createdAt(Instant.now()).updatedAt(Instant.now())
+                .build();
+    }
+
+    // --- Tests --- //
+
+    @Test
+    void list_returnsMappedResponses_whenProjectOwned() {
+        String owner = "u1"; String projectId = "p1";
+        when(projectRepo.findByIdAndOwnerId(projectId, owner))
+                .thenReturn(Optional.of(project(projectId, ProjectStatus.ACTIVE)));
+        when(taskRepo.findByProjectIdAndStatusOrderByOrderAsc(projectId, TaskStatus.TODO))
+                .thenReturn(List.of(task("t1", projectId, TaskStatus.TODO, 100)));
+
+        var res = service.list(owner, projectId, TaskStatus.TODO);
+
+        assertThat(res).hasSize(1);
+        assertThat(res.getFirst().getId()).isEqualTo("t1");
+    }
+
+    @Test
+    void list_throws_whenProjectNotOwned() {
+        when(projectRepo.findByIdAndOwnerId("pX", "u1")).thenReturn(Optional.empty());
+        assertThatThrownBy(() -> service.list("u1", "pX", TaskStatus.TODO))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("PROJECT_NOT_FOUND");
+    }
+
+    @Test
+    void create_defaultsStatusOrderPriority_andTrimsTitle() {
+        String owner = "u1"; String projectId = "p1";
+        when(projectRepo.findByIdAndOwnerId(projectId, owner))
+                .thenReturn(Optional.of(project(projectId, ProjectStatus.ACTIVE)));
+        when(taskRepo.findTopByProjectIdAndStatusOrderByOrderDesc(projectId, TaskStatus.TODO))
+                .thenReturn(null);
+
+        ArgumentCaptor<Task> saved = ArgumentCaptor.forClass(Task.class);
+        when(taskRepo.save(saved.capture())).thenAnswer(inv -> {
+            Task task = saved.getValue();
+            return Task.builder()
+                    .projectId(task.getProjectId()).title(task.getTitle())
+                    .description(task.getDescription()).status(task.getStatus())
+                    .order(task.getOrder()).priority(task.getPriority())
+                    .dueDate(task.getDueDate()).assigneeId(task.getAssigneeId())
+                    .createdAt(Instant.now()).updatedAt(Instant.now()).build();
+        });
+
+        var dto = new CreateTaskDto();
+        dto.setTitle("   Title   ");
+        TaskResponse res = service.create(owner, projectId, dto);
+
+        assertThat(res.getStatus()).isEqualTo(TaskStatus.TODO);
+        assertThat(res.getOrder()).isEqualTo(100);
+        assertThat(res.getPriority()).isEqualTo(TaskPriority.MEDIUM);
+        assertThat(saved.getValue().getTitle()).isEqualTo("Title");
+    }
+
+    @Test
+    void create_usesProvidedFields_andNextOrderWhenNoGreaterExists() {
+        String owner = "u1"; String projectId = "p1";
+        when(projectRepo.findByIdAndOwnerId(projectId, owner))
+                .thenReturn(Optional.of(project(projectId, ProjectStatus.ACTIVE)));
+        when(taskRepo.findTopByProjectIdAndStatusOrderByOrderDesc(projectId, TaskStatus.IN_PROGRESS))
+                .thenReturn(task("tLast", projectId, TaskStatus.IN_PROGRESS, 300));
+
+        var dto =  new CreateTaskDto();
+        dto.setTitle("X");
+        dto.setStatus(TaskStatus.IN_PROGRESS);
+        dto.setPriority(TaskPriority.HIGH);
+        when(taskRepo.save(any())).thenAnswer(i -> i.getArgument(0));
+
+        TaskResponse res = service.create(owner, projectId, dto);
+
+        assertThat(res.getOrder()).isEqualTo(400);
+        assertThat(res.getPriority()).isEqualTo(TaskPriority.HIGH);
+        assertThat(res.getStatus()).isEqualTo(TaskStatus.IN_PROGRESS);
+    }
+
+    @Test
+    void create_fails_whenProjectArchived() {
+        String owner = "u1"; String projectId = "p1";
+        when(projectRepo.findByIdAndOwnerId(projectId, owner))
+                .thenReturn(Optional.of(project(projectId, ProjectStatus.ARCHIVED)));
+
+        var dto = new CreateTaskDto(); dto.setTitle("X");
+
+        assertThatThrownBy(() -> service.create(owner, projectId, dto))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessage("PROJECT_ARCHIVED_READ_ONLY");
+    }
+
+    @Test
+    void update_changesColumn_withoutOrder_appendsToEndOfTargetColumn() {
+        Task existing = task("t1", "p1", TaskStatus.TODO, 200);
+        when(taskRepo.findById("t1")).thenReturn(Optional.of(existing));
+
+        when(projectRepo.findByIdAndOwnerId("p1", "u1")).thenReturn(Optional.of(project("p1", ProjectStatus.ACTIVE)));
+        when(taskRepo.findTopByProjectIdAndStatusOrderByOrderDesc("p1", TaskStatus.DONE))
+                .thenReturn(task("last", "p1", TaskStatus.DONE, 700));
+        when(taskRepo.save(any())).thenAnswer(i -> i.getArgument(0));
+
+        var dto = new UpdateTaskDto();
+        dto.setStatus(TaskStatus.DONE); // move column, no explicit order
+
+        TaskResponse res = service.update("u1", "t1", dto);
+
+        assertThat(res.getStatus()).isEqualTo(TaskStatus.DONE);
+        assertThat(res.getOrder()).isEqualTo(800);
+    }
+
+    @Test
+    void update_sameColumn_noOrder_keepsOrder() {
+        Task existing = task("t1", "p1", TaskStatus.TODO, 200);
+        when(taskRepo.findById("t1")).thenReturn(Optional.of(existing));
+        when(projectRepo.findByIdAndOwnerId("p1", "u1"))
+                .thenReturn(Optional.of(project("p1", ProjectStatus.ACTIVE)));
+        when(taskRepo.save(any())).thenAnswer(i -> i.getArgument(0));
+
+        var dto = new UpdateTaskDto(); // no changes
+
+        TaskResponse res = service.update("u1", "t1", dto);
+
+        assertThat(res.getOrder()).isEqualTo(200);
+        assertThat(res.getStatus()).isEqualTo(TaskStatus.TODO);
+    }
+
+    @Test
+    void update_withExplicitOrder_overridesOrder() {
+        Task existing = task("t1", "p1", TaskStatus.TODO, 200);
+        when(taskRepo.findById("t1")).thenReturn(Optional.of(existing));
+        when(projectRepo.findByIdAndOwnerId("p1", "u1"))
+                .thenReturn(Optional.of(project("p1", ProjectStatus.ACTIVE)));
+        when(taskRepo.save(any())).thenAnswer(i -> i.getArgument(0));
+
+        var dto = new UpdateTaskDto();
+        dto.setOrder(42);
+
+        TaskResponse res = service.update("u1", "t1", dto);
+        assertThat(res.getOrder()).isEqualTo(42);
+    }
+
+    @Test
+    void update_updatesOnlyProvidedFields() {
+        Task existing = task("t1", "p1", TaskStatus.TODO, 200);
+        when(taskRepo.findById("t1")).thenReturn(Optional.of(existing));
+        when(projectRepo.findByIdAndOwnerId("p1", "u1"))
+                .thenReturn(Optional.of(project("p1", ProjectStatus.ACTIVE)));
+        when(taskRepo.save(any())).thenAnswer(i -> i.getArgument(0));
+
+        var dto = new UpdateTaskDto();
+        dto.setTitle("   New    ");
+        dto.setDescription("Desc");
+        dto.setPriority(TaskPriority.LOW);
+
+        TaskResponse res = service.update("u1", "t1", dto);
+
+        assertThat(res.getTitle()).isEqualTo("New");
+        assertThat(res.getDescription()).isEqualTo("Desc");
+        assertThat(res.getPriority()).isEqualTo(TaskPriority.LOW);
+    }
+
+    @Test
+    void update_throws_whenTaskNotFound() {
+        when(taskRepo.findById("tX")).thenReturn(Optional.empty());
+        assertThatThrownBy(() -> service.update("u1", "tX", new UpdateTaskDto()))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("TASK_NOT_FOUND");
+    }
+
+    @Test
+    void update_throws_whenProjectNotOwned() {
+        Task existing = task("t1", "p1", TaskStatus.TODO, 100);
+        when(taskRepo.findById("t1")).thenReturn(Optional.of(existing));
+        when(projectRepo.findByIdAndOwnerId("p1", "u1")).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> service.update("u1", "t1", new UpdateTaskDto()))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("PROJECT_NOT_FOUND");
+    }
+
+    @Test
+    void deleteRemovesTask_whenOwned() {
+        Task existing = task("t1", "p1", TaskStatus.TODO, 100);
+        when(taskRepo.findById("t1")).thenReturn(Optional.of(existing));
+        when(projectRepo.findByIdAndOwnerId("p1", "u1"))
+                .thenReturn(Optional.of(project("p1", ProjectStatus.ACTIVE)));
+
+        service.delete("u1", "t1");
+
+        verify(taskRepo).delete(existing);
+    }
+
+    @Test
+    void delete_throws_whenTaskNotFound() {
+        when(taskRepo.findById("tX")).thenReturn(Optional.empty());
+        assertThatThrownBy(() -> service.delete("u1", "tX"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("TASK_NOT_FOUND");
+    }
+
+    @Test
+    void delete_throws_whenProjectNotOwned() {
+        Task existing = task("t1", "p1", TaskStatus.TODO, 100);
+        when(taskRepo.findById("t1")).thenReturn(Optional.of(existing));
+        when(projectRepo.findByIdAndOwnerId("p1", "u1")).thenReturn(Optional.empty());
+        assertThatThrownBy(() -> service.delete("u1", "t1"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("PROJECT_NOT_FOUND");
+    }
+}


### PR DESCRIPTION
- Tasks Domain

- Implement full Tasks domain (entity, DTOs, repository, service, controller) with JWT-secured endpoints.
- Support CRUD + list-by-status with strict ownership checks and archived-project guard.
- Ordering logic: default order = 100 step; move across columns appends to end; explicit order overrides.
- Validation + centralized exception mapping (*_NOT_FOUND → 404; others → 400).
- Add repository queries (sorted list, top-by-desc) and map entities → responses consistently.

- Tests

- Add unit tests for TaskService (defaults, guards, ordering, errors).
- Add TaskController MockMvc tests (201/200/204, 400 on invalid/missing).
- Use standalone MockMvc with custom @AuthenticationPrincipal resolver.