### PR TITLE
PR: Dockerize TaskRaum & set up CI/CD to Render

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,8 @@
+.git
+**/.DS_Store
+frontend/node_modules
+frontend/dist
+
+# ignore targets except the final jar
+backend/target/*
+!backend/target/taskraum.jar

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,80 @@
+name: Deploy TaskRaum
+on:
+  push:
+    branches: [ main ]
+
+env:
+  NODE_VERSION: '22'
+  JAVA_VERSION: '21'
+
+jobs:
+  build-frontend:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: 'npm'
+          cache-dependency-path: frontend/package-lock.json
+      - name: Build Frontend
+        working-directory: frontend
+        run: |
+          npm ci
+          npm run build
+      - uses: actions/upload-artifact@v4
+        with:
+          name: frontend-build
+          path: frontend/dist/
+
+  build-backend:
+    runs-on: ubuntu-latest
+    needs: build-frontend
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/download-artifact@v4
+        with:
+          name: frontend-build
+          path: backend/src/main/resources/static
+      - name: Setup JDK
+        uses: actions/setup-java@v4
+        with:
+          java-version: ${{ env.JAVA_VERSION }}
+          distribution: temurin
+          cache: maven
+      - name: Build with Maven (fat jar = taskraum.jar)
+        run: mvn -B -DskipTests package --file backend/pom.xml
+      - uses: actions/upload-artifact@v4
+        with:
+          name: taskraum.jar
+          path: backend/target/taskraum.jar
+
+  push-to-docker-hub:
+    runs-on: ubuntu-latest
+    needs: build-backend
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/download-artifact@v4
+        with:
+          name: taskraum.jar
+          path: backend/target
+      - uses: docker/setup-buildx-action@v3
+      - uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_PASSWORD }}
+      - uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./Dockerfile
+          push: true
+          tags: |
+            ${{ secrets.DOCKERHUB_IMAGE }}:latest
+            ${{ secrets.DOCKERHUB_IMAGE }}:${{ github.sha }}
+
+  deploy:
+    needs: push-to-docker-hub
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger Render Deployment
+        run: curl -s -X POST "${{ secrets.RENDER_DEPLOY_HOOK }}"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,16 @@
+# small Java 21 runtime
+FROM eclipse-temurin:21-jre-alpine
+
+# safer runtime (non-root), optional but recommended
+RUN addgroup -S app && adduser -S app -G app
+WORKDIR /app
+
+# CI produces this exact file
+COPY backend/target/taskraum.jar ./taskraum.jar
+
+EXPOSE 8080
+# let Render tweak memory without rebuilding
+ENV JAVA_OPTS="-XX:+UseContainerSupport -XX:MaxRAMPercentage=75.0"
+
+USER app
+ENTRYPOINT ["sh","-c","java $JAVA_OPTS -jar taskraum.jar"]

--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -89,6 +89,7 @@
     </dependencies>
 
     <build>
+        <finalName>taskraum</finalName>
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/backend/src/test/java/dev/taskraum/backend/projects/ProjectRepositoryTest.java
+++ b/backend/src/test/java/dev/taskraum/backend/projects/ProjectRepositoryTest.java
@@ -1,6 +1,7 @@
 package dev.taskraum.backend.projects;
 
 import dev.taskraum.backend.common.enums.ProjectStatus;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.data.mongo.DataMongoTest;
@@ -12,6 +13,11 @@ import static org.assertj.core.api.Assertions.assertThat;
 class ProjectRepositoryTest {
 
     @Autowired ProjectRepository repo;
+
+    @BeforeEach
+    void setUp() {
+        repo.deleteAll();
+    }
 
     @Test
     void queriesWorkAsExpected() {

--- a/backend/src/test/java/dev/taskraum/backend/tasks/TaskRepositoryTest.java
+++ b/backend/src/test/java/dev/taskraum/backend/tasks/TaskRepositoryTest.java
@@ -2,6 +2,7 @@ package dev.taskraum.backend.tasks;
 
 import dev.taskraum.backend.common.enums.TaskPriority;
 import dev.taskraum.backend.common.enums.TaskStatus;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.data.mongo.DataMongoTest;
@@ -15,6 +16,11 @@ import static org.assertj.core.api.Assertions.assertThat;
 class TaskRepositoryTest {
 
     @Autowired private TaskRepository repo;
+
+    @BeforeEach
+    void setUp() {
+        repo.deleteAll();
+    }
 
     private Task task(String id, String projectId, TaskStatus status, int order) {
         return Task.builder()


### PR DESCRIPTION
Summary

Containerize TaskRaum backend.

Build FE → embed into BE → push Docker image → trigger Render deploy.

Keep Maven as-is (already outputs taskraum.jar).

What changed

Tests

Clean repositories in @BeforeEach to prevent data leakage
(ProjectRepositoryTest, TaskRepositoryTest).

Docker

Dockerfile (Java 21, small JRE, non-root user, tunable JAVA_OPTS).

.dockerignore to shrink build context (keeps only backend/target/taskraum.jar).

CI/CD

.github/workflows/deploy.yml

Build FE (frontend/dist)

Copy into BE static, package taskraum.jar

Build & push Docker image (${{ secrets.DOCKERHUB_IMAGE }})

Trigger Render via deploy hook

How it works (step by step)

Build FE → upload artifact.

Download into BE → mvn package → produces backend/target/taskraum.jar.

Docker builds image from taskraum.jar → pushes to Docker Hub.

Render deploy hook pulls the new image and restarts the service.

Config / Secrets

DOCKERHUB_USERNAME, DOCKERHUB_PASSWORD

DOCKERHUB_IMAGE

RENDER_DEPLOY_HOOK

Test plan

✅ GitHub Actions on branch: unit tests pass.

✅ On merge to main:

Check workflow stages: FE build → BE package → image push → render trigger.

Verify Docker Hub has tags: latest and SHA.

Open Render logs; app responds on port 8080.