### PR TITLE
fix(web): forward SPA routes and allow dev/prod origins

### DIFF
--- a/backend/src/main/java/dev/taskraum/backend/config/SecurityConfig.java
+++ b/backend/src/main/java/dev/taskraum/backend/config/SecurityConfig.java
@@ -34,6 +34,7 @@ public class SecurityConfig {
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers("/auth/**").permitAll()
                         .requestMatchers("/", "/index.html", "/assets/**").permitAll()
+                        .requestMatchers("/app", "/app/**").permitAll()
                         .anyRequest().authenticated())
                 .addFilterBefore(jwtAuthFilter, UsernamePasswordAuthenticationFilter.class);
         return http.build();
@@ -48,7 +49,9 @@ public class SecurityConfig {
     CorsConfigurationSource corsConfigurationSource() {
         CorsConfiguration config = new CorsConfiguration();
         // Important: since cookies being sent, DO NOT use "*"
-        config.setAllowedOrigins(java.util.List.of("http://localhost:5173"));
+        config.setAllowedOrigins(java.util.List.of("http://localhost:5173",
+                "http://localhost:8080",
+                "https://taskraum.onrender.com"));
         config.setAllowedMethods(java.util.List.of("GET","POST","PUT","DELETE","PATCH","OPTIONS"));
         config.setAllowedHeaders(java.util.List.of("Content-Type","Authorization"));
         config.setAllowCredentials(true); // required for cookies

--- a/backend/src/main/java/dev/taskraum/backend/web/SpaController.java
+++ b/backend/src/main/java/dev/taskraum/backend/web/SpaController.java
@@ -1,0 +1,12 @@
+package dev.taskraum.backend.web;
+
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+
+@Controller
+public class SpaController {
+    @GetMapping({"/app", "/app/**"})
+    public String forwardApp() {
+        return "forward:/index.html";
+    }
+}


### PR DESCRIPTION
- Add SpaController to forward /app and subpaths to index.html
- Update SecurityConfig: permit /app/** and set allowed origins for localhost:5173, localhost:8080, and taskraum.onrender.com
- Enables clean URL refresh/deep-linking without 403 and avoids CORS issues