### PR TITLE
fix(web): use AntPathMatcher to support catch-all SPA routing

### DIFF
--- a/backend/src/main/java/dev/taskraum/backend/config/SecurityConfig.java
+++ b/backend/src/main/java/dev/taskraum/backend/config/SecurityConfig.java
@@ -34,7 +34,9 @@ public class SecurityConfig {
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers("/auth/**").permitAll()
                         .requestMatchers("/", "/index.html", "/assets/**").permitAll()
-                        .requestMatchers("/app", "/app/**").permitAll()
+                        // permit all "non-dot" paths (SPA routes)
+                        .requestMatchers("/{path:^(?!auth|api|assets|index\\.html)[^\\.]*}",
+                                "/**/{path:^(?!auth|api|assets)[^\\.]*}").permitAll()
                         .anyRequest().authenticated())
                 .addFilterBefore(jwtAuthFilter, UsernamePasswordAuthenticationFilter.class);
         return http.build();

--- a/backend/src/main/java/dev/taskraum/backend/web/SpaController.java
+++ b/backend/src/main/java/dev/taskraum/backend/web/SpaController.java
@@ -5,8 +5,16 @@ import org.springframework.web.bind.annotation.GetMapping;
 
 @Controller
 public class SpaController {
-    @GetMapping({"/app", "/app/**"})
-    public String forwardApp() {
+
+    // Top-level SPA routes without dots
+    @GetMapping("/{path:[^.]*}")
+    public String forwardTop() {
+        return "forward:/index.html";
+    }
+
+    // Nested SPA routes without dots
+    @GetMapping("/**/{path:[^.]*}")
+    public String forwardNested() {
         return "forward:/index.html";
     }
 }

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -1,4 +1,5 @@
 spring.autoconfigure.exclude=org.springframework.boot.autoconfigure.security.servlet.UserDetailsServiceAutoConfiguration
+spring.mvc.pathmatch.matching-strategy=ant_path_matcher
 spring.application.name=backend
 spring.data.mongodb.uri=${MONGODB_URI}
 jwt.secret=${JWT_SECRET}


### PR DESCRIPTION
- Switched path matching strategy to ant_path_matcher
- Added catch-all mappings in SpaController to forward non-file routes to index.html
- Updated SecurityConfig to permit these non-file SPA routes
- Fixes 403 errors when refreshing or deep-linking to public SPA pages